### PR TITLE
NOISSUE - Optimize logs output

### DIFF
--- a/examples/simple/simple.go
+++ b/examples/simple/simple.go
@@ -39,28 +39,26 @@ func (e *Event) AuthPublish(username, clientID string, topic *string, payload *[
 // AuthSubscribe is called on device publish,
 // prior forwarding to the MQTT broker
 func (e *Event) AuthSubscribe(username, clientID string, topics *[]string) error {
-
 	e.logger.Info(fmt.Sprintf("AuthSubscribe() - clientID: %s, topics: %s", clientID, strings.Join(*topics, ",")))
 	return nil
 }
 
-// Register - after client sucesfully connected
+// Register - after client successfully connected
 func (e *Event) Register(clientID string) {
 	e.logger.Info(fmt.Sprintf("Register() - clientID: %s", clientID))
 }
 
-// Publish - after client sucesfully published
+// Publish - after client successfully published
 func (e *Event) Publish(clientID, topic string, payload []byte) {
 	e.logger.Info(fmt.Sprintf("Publish() - clientID: %s, topic: %s, payload: %s", clientID, topic, string(payload)))
 }
 
-// Subscribe - after client sucesfully subscribed
+// Subscribe - after client successfully subscribed
 func (e *Event) Subscribe(clientID string, topics []string) {
 	e.logger.Info(fmt.Sprintf("Subscribe() - clientID: %s, topics: %s", clientID, strings.Join(topics, ",")))
 }
 
-// Unubscribe - after client unsubscribed
-func (e *Event) Unubscribe(clientID string, topics []string) {
-
-	e.logger.Info(fmt.Sprintf("Unubscribe() - clientID: %s, topics: %s", clientID, strings.Join(topics, ",")))
+// Unsubscribe - after client unsubscribed
+func (e *Event) Unsubscribe(clientID string, topics []string) {
+	e.logger.Info(fmt.Sprintf("Unsubscribe() - clientID: %s, topics: %s", clientID, strings.Join(topics, ",")))
 }

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -2,27 +2,27 @@ package events
 
 // Event is an interface for mProxy hooks
 type Event interface {
-	// Athorization on client `CONNECT`
+	// Authorization on client `CONNECT`
 	// Each of the params are passed by reference, so that it can be changed
 	AuthRegister(username, clientID *string, password *[]byte) error
 
-	// Athorization on client `PUBLISH`
+	// Authorization on client `PUBLISH`
 	// Topic is passed by reference, so that it can be modified
 	AuthPublish(username, clientID string, topic *string, payload *[]byte) error
 
-	// Athorization on client `SUBSCRIBE`
+	// Authorization on client `SUBSCRIBE`
 	// Topics are passed by reference, so that they can be modified
 	AuthSubscribe(username, clientID string, topics *[]string) error
 
-	// After client sucesfully connected
+	// After client successfully connected
 	Register(clientID string)
 
-	// After client sucesfully published
+	// After client successfully published
 	Publish(clientID, topic string, payload []byte)
 
-	// After client sucesfully subscribed
+	// After client successfully subscribed
 	Subscribe(clientID string, topics []string)
 
 	// After client unsubscribed
-	Unubscribe(clientID string, topics []string)
+	Unsubscribe(clientID string, topics []string)
 }

--- a/pkg/mqtt/session.go
+++ b/pkg/mqtt/session.go
@@ -107,7 +107,7 @@ func (s *session) notify(pkt packets.ControlPacket) {
 	case *packets.SubscribePacket:
 		s.event.Subscribe(s.client.ID, p.Topics)
 	case *packets.UnsubscribePacket:
-		s.event.Unubscribe(s.client.ID, p.Topics)
+		s.event.Unsubscribe(s.client.ID, p.Topics)
 	default:
 		return
 	}


### PR DESCRIPTION
Replace `Sprintf` with string concatenation in logs. Fix typos.