### PR TITLE
NOISSUE - Pass MQTT client to Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ in device-mProxy socket (OUTBOUND or DOWNLINK).
 <p align="center"><img src="docs/img/mproxy.png"></p>
 
 mProxy can parse and understand MQTT packages, and upon their detection it actually calls external event handlers.
-Event handlers should implement the following interface defined in [pkg/events/events.go](pkg/events/events.go):
+Event handlers should implement the following interface defined in [pkg/mqtt/events.go](pkg/mqtt/events.go):
 
 ```go
 // Event is an interface for mProxy hooks

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -10,9 +10,8 @@ import (
 
 	"github.com/mainflux/mainflux/logger"
 	"github.com/mainflux/mproxy/examples/simple"
-	"github.com/mainflux/mproxy/pkg/events"
 	hp "github.com/mainflux/mproxy/pkg/http"
-	mp "github.com/mainflux/mproxy/pkg/mqtt"
+	"github.com/mainflux/mproxy/pkg/mqtt"
 )
 
 const (
@@ -113,7 +112,7 @@ func loadConfig() config {
 	}
 }
 
-func proxyHTTP(cfg config, logger logger.Logger, evt events.Event, errs chan error) {
+func proxyHTTP(cfg config, logger logger.Logger, evt mqtt.Event, errs chan error) {
 	hp := hp.New(cfg.httpTargetHost, cfg.httpTargetPort, evt, logger)
 	http.Handle("/", hp.ReverseProxy)
 
@@ -121,8 +120,8 @@ func proxyHTTP(cfg config, logger logger.Logger, evt events.Event, errs chan err
 	errs <- http.ListenAndServe(p, nil)
 }
 
-func proxyMQTT(cfg config, logger logger.Logger, evt events.Event, errs chan error) {
-	mp := mp.New(cfg.mqttHost, cfg.mqttPort, cfg.mqttTargetHost, cfg.mqttTargetPort, evt, logger)
+func proxyMQTT(cfg config, logger logger.Logger, evt mqtt.Event, errs chan error) {
+	mp := mqtt.New(cfg.mqttHost, cfg.mqttPort, cfg.mqttTargetHost, cfg.mqttTargetPort, evt, logger)
 
 	errs <- mp.Proxy()
 }

--- a/examples/simple/simple.go
+++ b/examples/simple/simple.go
@@ -24,46 +24,46 @@ func New(logger logger.Logger) *Event {
 
 // AuthConnect is called on device connection,
 // prior forwarding to the MQTT broker
-func (e *Event) AuthConnect(c mqtt.Client) error {
+func (e *Event) AuthConnect(c *mqtt.Client) error {
 	e.logger.Info(fmt.Sprintf("AuthRegister() - clientID: %s, username: %s, password: %s", c.ID, c.Username, string(c.Password)))
 	return nil
 }
 
 // AuthPublish is called on device publish,
 // prior forwarding to the MQTT broker
-func (e *Event) AuthPublish(c mqtt.Client, topic string, payload []byte) error {
-	e.logger.Info(fmt.Sprintf("AuthPublish() - clientID: %s, topic: %s, payload: %s", c.ID, topic, string(payload)))
+func (e *Event) AuthPublish(c *mqtt.Client, topic *string, payload []byte) error {
+	e.logger.Info(fmt.Sprintf("AuthPublish() - clientID: %s, topic: %s, payload: %s", c.ID, *topic, string(payload)))
 	return nil
 }
 
 // AuthSubscribe is called on device publish,
 // prior forwarding to the MQTT broker
-func (e *Event) AuthSubscribe(c mqtt.Client, topics []string) error {
+func (e *Event) AuthSubscribe(c *mqtt.Client, topics []string) error {
 	e.logger.Info(fmt.Sprintf("AuthSubscribe() - clientID: %s, topics: %s", c.ID, strings.Join(topics, ",")))
 	return nil
 }
 
 // Connect - after client successfully connected
-func (e *Event) Connect(c mqtt.Client) {
+func (e *Event) Connect(c *mqtt.Client) {
 	e.logger.Info(fmt.Sprintf("Register() - username: %s, clientID: %s", c.Username, c.ID))
 }
 
 // Publish - after client successfully published
-func (e *Event) Publish(c mqtt.Client, topic string, payload []byte) {
-	e.logger.Info(fmt.Sprintf("Publish() - username: %s, clientID: %s, topic: %s, payload: %s", c.Username, c.ID, topic, string(payload)))
+func (e *Event) Publish(c *mqtt.Client, topic *string, payload []byte) {
+	e.logger.Info(fmt.Sprintf("Publish() - username: %s, clientID: %s, topic: %s, payload: %s", c.Username, c.ID, *topic, string(payload)))
 }
 
 // Subscribe - after client successfully subscribed
-func (e *Event) Subscribe(c mqtt.Client, topics []string) {
+func (e *Event) Subscribe(c *mqtt.Client, topics []string) {
 	e.logger.Info(fmt.Sprintf("Subscribe() - username: %s, clientID: %s, topics: %s", c.Username, c.ID, strings.Join(topics, ",")))
 }
 
 // Unsubscribe - after client unsubscribed
-func (e *Event) Unsubscribe(c mqtt.Client, topics []string) {
+func (e *Event) Unsubscribe(c *mqtt.Client, topics []string) {
 	e.logger.Info(fmt.Sprintf("Unsubscribe() - username: %s, clientID: %s, topics: %s", c.Username, c.ID, strings.Join(topics, ",")))
 }
 
 // Disconnect on conection lost
-func (e *Event) Disconnect(c mqtt.Client) {
+func (e *Event) Disconnect(c *mqtt.Client) {
 	e.logger.Info(fmt.Sprintf("Disconnect() - client with username: %s and ID: %s disconenectd", c.Username, c.ID))
 }

--- a/examples/simple/simple.go
+++ b/examples/simple/simple.go
@@ -5,12 +5,12 @@ import (
 	"strings"
 
 	"github.com/mainflux/mainflux/logger"
-	"github.com/mainflux/mproxy/pkg/events"
+	"github.com/mainflux/mproxy/pkg/mqtt"
 )
 
-var _ events.Event = (*Event)(nil)
+var _ mqtt.Event = (*Event)(nil)
 
-// Event implements events.Event interface
+// Event implements mqtt.Event interface
 type Event struct {
 	logger logger.Logger
 }
@@ -24,46 +24,46 @@ func New(logger logger.Logger) *Event {
 
 // AuthConnect is called on device connection,
 // prior forwarding to the MQTT broker
-func (e *Event) AuthConnect(username, clientID *string, password *[]byte) error {
-	e.logger.Info(fmt.Sprintf("AuthRegister() - clientID: %s, username: %s, password: %s", *clientID, *username, string(*password)))
+func (e *Event) AuthConnect(c mqtt.Client) error {
+	e.logger.Info(fmt.Sprintf("AuthRegister() - clientID: %s, username: %s, password: %s", c.ID, c.Username, string(c.Password)))
 	return nil
 }
 
 // AuthPublish is called on device publish,
 // prior forwarding to the MQTT broker
-func (e *Event) AuthPublish(username, clientID string, topic *string, payload *[]byte) error {
-	e.logger.Info(fmt.Sprintf("AuthPublish() - clientID: %s, topic: %s, payload: %s", clientID, *topic, string(*payload)))
+func (e *Event) AuthPublish(c mqtt.Client, topic string, payload []byte) error {
+	e.logger.Info(fmt.Sprintf("AuthPublish() - clientID: %s, topic: %s, payload: %s", c.ID, topic, string(payload)))
 	return nil
 }
 
 // AuthSubscribe is called on device publish,
 // prior forwarding to the MQTT broker
-func (e *Event) AuthSubscribe(username, clientID string, topics *[]string) error {
-	e.logger.Info(fmt.Sprintf("AuthSubscribe() - clientID: %s, topics: %s", clientID, strings.Join(*topics, ",")))
+func (e *Event) AuthSubscribe(c mqtt.Client, topics []string) error {
+	e.logger.Info(fmt.Sprintf("AuthSubscribe() - clientID: %s, topics: %s", c.ID, strings.Join(topics, ",")))
 	return nil
 }
 
 // Connect - after client successfully connected
-func (e *Event) Connect(username, clientID string) {
-	e.logger.Info(fmt.Sprintf("Register() - username: %s, clientID: %s", username, clientID))
+func (e *Event) Connect(c mqtt.Client) {
+	e.logger.Info(fmt.Sprintf("Register() - username: %s, clientID: %s", c.Username, c.ID))
 }
 
 // Publish - after client successfully published
-func (e *Event) Publish(username, clientID, topic string, payload []byte) {
-	e.logger.Info(fmt.Sprintf("Publish() - username: %s, clientID: %s, topic: %s, payload: %s", username, clientID, topic, string(payload)))
+func (e *Event) Publish(c mqtt.Client, topic string, payload []byte) {
+	e.logger.Info(fmt.Sprintf("Publish() - username: %s, clientID: %s, topic: %s, payload: %s", c.Username, c.ID, topic, string(payload)))
 }
 
 // Subscribe - after client successfully subscribed
-func (e *Event) Subscribe(username, clientID string, topics []string) {
-	e.logger.Info(fmt.Sprintf("Subscribe() - username: %s, clientID: %s, topics: %s", username, clientID, strings.Join(topics, ",")))
+func (e *Event) Subscribe(c mqtt.Client, topics []string) {
+	e.logger.Info(fmt.Sprintf("Subscribe() - username: %s, clientID: %s, topics: %s", c.Username, c.ID, strings.Join(topics, ",")))
 }
 
 // Unsubscribe - after client unsubscribed
-func (e *Event) Unsubscribe(username, clientID string, topics []string) {
-	e.logger.Info(fmt.Sprintf("Unsubscribe() - username: %s, clientID: %s, topics: %s", username, clientID, strings.Join(topics, ",")))
+func (e *Event) Unsubscribe(c mqtt.Client, topics []string) {
+	e.logger.Info(fmt.Sprintf("Unsubscribe() - username: %s, clientID: %s, topics: %s", c.Username, c.ID, strings.Join(topics, ",")))
 }
 
 // Disconnect on conection lost
-func (e *Event) Disconnect(username, clientID string) {
-	e.logger.Info(fmt.Sprintf("Disconnect() - client with username: %s and ID: %s disconenectd", username, clientID))
+func (e *Event) Disconnect(c mqtt.Client) {
+	e.logger.Info(fmt.Sprintf("Disconnect() - client with username: %s and ID: %s disconenectd", c.Username, c.ID))
 }

--- a/examples/simple/simple.go
+++ b/examples/simple/simple.go
@@ -31,15 +31,15 @@ func (e *Event) AuthConnect(c *mqtt.Client) error {
 
 // AuthPublish is called on device publish,
 // prior forwarding to the MQTT broker
-func (e *Event) AuthPublish(c *mqtt.Client, topic *string, payload []byte) error {
-	e.logger.Info(fmt.Sprintf("AuthPublish() - clientID: %s, topic: %s, payload: %s", c.ID, *topic, string(payload)))
+func (e *Event) AuthPublish(c *mqtt.Client, topic *string, payload *[]byte) error {
+	e.logger.Info(fmt.Sprintf("AuthPublish() - clientID: %s, topic: %s, payload: %s", c.ID, *topic, string(*payload)))
 	return nil
 }
 
 // AuthSubscribe is called on device publish,
 // prior forwarding to the MQTT broker
-func (e *Event) AuthSubscribe(c *mqtt.Client, topics []string) error {
-	e.logger.Info(fmt.Sprintf("AuthSubscribe() - clientID: %s, topics: %s", c.ID, strings.Join(topics, ",")))
+func (e *Event) AuthSubscribe(c *mqtt.Client, topics *[]string) error {
+	e.logger.Info(fmt.Sprintf("AuthSubscribe() - clientID: %s, topics: %s", c.ID, strings.Join(*topics, ",")))
 	return nil
 }
 
@@ -49,18 +49,18 @@ func (e *Event) Connect(c *mqtt.Client) {
 }
 
 // Publish - after client successfully published
-func (e *Event) Publish(c *mqtt.Client, topic *string, payload []byte) {
-	e.logger.Info(fmt.Sprintf("Publish() - username: %s, clientID: %s, topic: %s, payload: %s", c.Username, c.ID, *topic, string(payload)))
+func (e *Event) Publish(c *mqtt.Client, topic *string, payload *[]byte) {
+	e.logger.Info(fmt.Sprintf("Publish() - username: %s, clientID: %s, topic: %s, payload: %s", c.Username, c.ID, *topic, string(*payload)))
 }
 
 // Subscribe - after client successfully subscribed
-func (e *Event) Subscribe(c *mqtt.Client, topics []string) {
-	e.logger.Info(fmt.Sprintf("Subscribe() - username: %s, clientID: %s, topics: %s", c.Username, c.ID, strings.Join(topics, ",")))
+func (e *Event) Subscribe(c *mqtt.Client, topics *[]string) {
+	e.logger.Info(fmt.Sprintf("Subscribe() - username: %s, clientID: %s, topics: %s", c.Username, c.ID, strings.Join(*topics, ",")))
 }
 
 // Unsubscribe - after client unsubscribed
-func (e *Event) Unsubscribe(c *mqtt.Client, topics []string) {
-	e.logger.Info(fmt.Sprintf("Unsubscribe() - username: %s, clientID: %s, topics: %s", c.Username, c.ID, strings.Join(topics, ",")))
+func (e *Event) Unsubscribe(c *mqtt.Client, topics *[]string) {
+	e.logger.Info(fmt.Sprintf("Unsubscribe() - username: %s, clientID: %s, topics: %s", c.Username, c.ID, strings.Join(*topics, ",")))
 }
 
 // Disconnect on conection lost

--- a/pkg/http/proxy.go
+++ b/pkg/http/proxy.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 
 	"github.com/mainflux/mainflux/logger"
-	"github.com/mainflux/mproxy/pkg/events"
+	"github.com/mainflux/mproxy/pkg/mqtt"
 )
 
 // Proxy - struct that holds HTTP proxy info
@@ -15,12 +15,12 @@ type Proxy struct {
 	host         string
 	port         string
 	ReverseProxy *httputil.ReverseProxy
-	event        events.Event
+	event        mqtt.Event
 	logger       logger.Logger
 }
 
 // New - creates new HTTP proxy
-func New(host, port string, event events.Event, logger logger.Logger) *Proxy {
+func New(host, port string, event mqtt.Event, logger logger.Logger) *Proxy {
 	url := url.URL{
 		Host: fmt.Sprintf("%s:%s", host, port),
 	}

--- a/pkg/mqtt/client.go
+++ b/pkg/mqtt/client.go
@@ -1,0 +1,8 @@
+package mqtt
+
+// Client stores MQTT client data.
+type Client struct {
+	ID       string
+	Username string
+	Password []byte
+}

--- a/pkg/mqtt/events.go
+++ b/pkg/mqtt/events.go
@@ -4,28 +4,28 @@ package mqtt
 type Event interface {
 	// Authorization on client `CONNECT`
 	// Each of the params are passed by reference, so that it can be changed
-	AuthConnect(client Client) error
+	AuthConnect(client *Client) error
 
 	// Authorization on client `PUBLISH`
 	// Topic is passed by reference, so that it can be modified
-	AuthPublish(client Client, topic string, payload []byte) error
+	AuthPublish(client *Client, topic *string, payload []byte) error
 
 	// Authorization on client `SUBSCRIBE`
 	// Topics are passed by reference, so that they can be modified
-	AuthSubscribe(client Client, topics []string) error
+	AuthSubscribe(client *Client, topics []string) error
 
 	// After client successfully connected
-	Connect(client Client)
+	Connect(client *Client)
 
 	// After client successfully published
-	Publish(client Client, topic string, payload []byte)
+	Publish(client *Client, topic *string, payload []byte)
 
 	// After client successfully subscribed
-	Subscribe(client Client, topics []string)
+	Subscribe(client *Client, topics []string)
 
 	// After client unsubscribed
-	Unsubscribe(client Client, topics []string)
+	Unsubscribe(client *Client, topics []string)
 
 	// Disconnect on connection with client lost
-	Disconnect(client Client)
+	Disconnect(client *Client)
 }

--- a/pkg/mqtt/events.go
+++ b/pkg/mqtt/events.go
@@ -1,31 +1,31 @@
-package events
+package mqtt
 
 // Event is an interface for mProxy hooks
 type Event interface {
 	// Authorization on client `CONNECT`
 	// Each of the params are passed by reference, so that it can be changed
-	AuthConnect(username, clientID *string, password *[]byte) error
+	AuthConnect(client Client) error
 
 	// Authorization on client `PUBLISH`
 	// Topic is passed by reference, so that it can be modified
-	AuthPublish(username, clientID string, topic *string, payload *[]byte) error
+	AuthPublish(client Client, topic string, payload []byte) error
 
 	// Authorization on client `SUBSCRIBE`
 	// Topics are passed by reference, so that they can be modified
-	AuthSubscribe(username, clientID string, topics *[]string) error
+	AuthSubscribe(client Client, topics []string) error
 
 	// After client successfully connected
-	Connect(username, clientID string)
+	Connect(client Client)
 
 	// After client successfully published
-	Publish(username, clientID, topic string, payload []byte)
+	Publish(client Client, topic string, payload []byte)
 
 	// After client successfully subscribed
-	Subscribe(username, clientID string, topics []string)
+	Subscribe(client Client, topics []string)
 
 	// After client unsubscribed
-	Unsubscribe(username, clientID string, topics []string)
+	Unsubscribe(client Client, topics []string)
 
 	// Disconnect on connection with client lost
-	Disconnect(username, clientID string)
+	Disconnect(client Client)
 }

--- a/pkg/mqtt/events.go
+++ b/pkg/mqtt/events.go
@@ -8,23 +8,23 @@ type Event interface {
 
 	// Authorization on client `PUBLISH`
 	// Topic is passed by reference, so that it can be modified
-	AuthPublish(client *Client, topic *string, payload []byte) error
+	AuthPublish(client *Client, topic *string, payload *[]byte) error
 
 	// Authorization on client `SUBSCRIBE`
 	// Topics are passed by reference, so that they can be modified
-	AuthSubscribe(client *Client, topics []string) error
+	AuthSubscribe(client *Client, topics *[]string) error
 
 	// After client successfully connected
 	Connect(client *Client)
 
 	// After client successfully published
-	Publish(client *Client, topic *string, payload []byte)
+	Publish(client *Client, topic *string, payload *[]byte)
 
 	// After client successfully subscribed
-	Subscribe(client *Client, topics []string)
+	Subscribe(client *Client, topics *[]string)
 
 	// After client unsubscribed
-	Unsubscribe(client *Client, topics []string)
+	Unsubscribe(client *Client, topics *[]string)
 
 	// Disconnect on connection with client lost
 	Disconnect(client *Client)

--- a/pkg/mqtt/proxy.go
+++ b/pkg/mqtt/proxy.go
@@ -6,7 +6,6 @@ import (
 	"net"
 
 	"github.com/mainflux/mainflux/logger"
-	"github.com/mainflux/mproxy/pkg/events"
 )
 
 // Proxy is main MQTT proxy struct
@@ -14,12 +13,12 @@ type Proxy struct {
 	host   string
 	port   string
 	target string
-	event  events.Event
+	event  Event
 	logger logger.Logger
 }
 
 // New will setup a new Proxy struct after parsing the options
-func New(host, port, targetHost, targetPort string, event events.Event, logger logger.Logger) *Proxy {
+func New(host, port, targetHost, targetPort string, event Event, logger logger.Logger) *Proxy {
 	return &Proxy{
 		host:   host,
 		port:   port,

--- a/pkg/mqtt/session.go
+++ b/pkg/mqtt/session.go
@@ -80,7 +80,14 @@ func (s *session) authorize(pkt packets.ControlPacket) error {
 			Username: p.Username,
 			Password: p.Password,
 		}
-		return s.event.AuthConnect(&s.client)
+		if err := s.event.AuthConnect(&s.client); err != nil {
+			return nil
+		}
+		// Copy back to the packet in case values are changed by Event handler.
+		// This is specific to CONN, as only that package type has credentials.
+		p.ClientIdentifier = s.client.ID
+		p.Username = s.client.Username
+		p.Password = s.client.Password
 	case *packets.PublishPacket:
 		return s.event.AuthPublish(&s.client, &p.TopicName, p.Payload)
 	case *packets.SubscribePacket:

--- a/pkg/mqtt/session.go
+++ b/pkg/mqtt/session.go
@@ -81,17 +81,18 @@ func (s *session) authorize(pkt packets.ControlPacket) error {
 			Password: p.Password,
 		}
 		if err := s.event.AuthConnect(&s.client); err != nil {
-			return nil
+			return err
 		}
 		// Copy back to the packet in case values are changed by Event handler.
 		// This is specific to CONN, as only that package type has credentials.
 		p.ClientIdentifier = s.client.ID
 		p.Username = s.client.Username
 		p.Password = s.client.Password
+		return nil
 	case *packets.PublishPacket:
-		return s.event.AuthPublish(&s.client, &p.TopicName, p.Payload)
+		return s.event.AuthPublish(&s.client, &p.TopicName, &p.Payload)
 	case *packets.SubscribePacket:
-		return s.event.AuthSubscribe(&s.client, p.Topics)
+		return s.event.AuthSubscribe(&s.client, &p.Topics)
 	default:
 		return nil
 	}
@@ -102,11 +103,11 @@ func (s *session) notify(pkt packets.ControlPacket) {
 	case *packets.ConnectPacket:
 		s.event.Connect(&s.client)
 	case *packets.PublishPacket:
-		s.event.Publish(&s.client, &p.TopicName, p.Payload)
+		s.event.Publish(&s.client, &p.TopicName, &p.Payload)
 	case *packets.SubscribePacket:
-		s.event.Subscribe(&s.client, p.Topics)
+		s.event.Subscribe(&s.client, &p.Topics)
 	case *packets.UnsubscribePacket:
-		s.event.Unsubscribe(&s.client, p.Topics)
+		s.event.Unsubscribe(&s.client, &p.Topics)
 	default:
 		return
 	}

--- a/pkg/mqtt/session.go
+++ b/pkg/mqtt/session.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/eclipse/paho.mqtt.golang/packets"
 	"github.com/mainflux/mainflux/logger"
-	"github.com/mainflux/mproxy/pkg/events"
 )
 
 const (
@@ -15,21 +14,15 @@ const (
 
 type direction int
 
-type mqttClient struct {
-	ID       string
-	username string
-	password []byte
-}
-
 type session struct {
 	logger   logger.Logger
 	inbound  net.Conn
 	outbound net.Conn
-	event    events.Event
-	client   mqttClient
+	event    Event
+	client   Client
 }
 
-func newSession(inbound, outbound net.Conn, event events.Event, logger logger.Logger) *session {
+func newSession(inbound, outbound net.Conn, event Event, logger logger.Logger) *session {
 	return &session{
 		logger:   logger,
 		inbound:  inbound,
@@ -47,7 +40,7 @@ func (s *session) stream() error {
 	go s.streamUnidir(down, s.outbound, s.inbound, errs)
 
 	err := <-errs
-	s.event.Disconnect(s.client.username, s.client.ID)
+	s.event.Disconnect(s.client)
 	return err
 }
 
@@ -82,17 +75,16 @@ func (s *session) streamUnidir(dir direction, r, w net.Conn, errs chan error) {
 func (s *session) authorize(pkt packets.ControlPacket) error {
 	switch p := pkt.(type) {
 	case *packets.ConnectPacket:
-		if err := s.event.AuthConnect(&p.Username, &p.ClientIdentifier, &p.Password); err != nil {
-			return err
+		s.client = Client{
+			ID:       p.ClientIdentifier,
+			Username: p.Username,
+			Password: p.Password,
 		}
-		s.client.username = p.Username
-		s.client.password = p.Password
-		s.client.ID = p.ClientIdentifier
-		return nil
+		return s.event.AuthConnect(s.client)
 	case *packets.PublishPacket:
-		return s.event.AuthPublish(s.client.username, s.client.ID, &p.TopicName, &p.Payload)
+		return s.event.AuthPublish(s.client, p.TopicName, p.Payload)
 	case *packets.SubscribePacket:
-		return s.event.AuthSubscribe(s.client.username, s.client.ID, &p.Topics)
+		return s.event.AuthSubscribe(s.client, p.Topics)
 	default:
 		return nil
 	}
@@ -101,13 +93,13 @@ func (s *session) authorize(pkt packets.ControlPacket) error {
 func (s *session) notify(pkt packets.ControlPacket) {
 	switch p := pkt.(type) {
 	case *packets.ConnectPacket:
-		s.event.Connect(s.client.username, s.client.ID)
+		s.event.Connect(s.client)
 	case *packets.PublishPacket:
-		s.event.Publish(s.client.username, s.client.ID, p.TopicName, p.Payload)
+		s.event.Publish(s.client, p.TopicName, p.Payload)
 	case *packets.SubscribePacket:
-		s.event.Subscribe(s.client.username, s.client.ID, p.Topics)
+		s.event.Subscribe(s.client, p.Topics)
 	case *packets.UnsubscribePacket:
-		s.event.Unsubscribe(s.client.username, s.client.ID, p.Topics)
+		s.event.Unsubscribe(s.client, p.Topics)
 	default:
 		return
 	}

--- a/pkg/mqtt/session.go
+++ b/pkg/mqtt/session.go
@@ -40,7 +40,7 @@ func (s *session) stream() error {
 	go s.streamUnidir(down, s.outbound, s.inbound, errs)
 
 	err := <-errs
-	s.event.Disconnect(s.client)
+	s.event.Disconnect(&s.client)
 	return err
 }
 
@@ -80,11 +80,11 @@ func (s *session) authorize(pkt packets.ControlPacket) error {
 			Username: p.Username,
 			Password: p.Password,
 		}
-		return s.event.AuthConnect(s.client)
+		return s.event.AuthConnect(&s.client)
 	case *packets.PublishPacket:
-		return s.event.AuthPublish(s.client, p.TopicName, p.Payload)
+		return s.event.AuthPublish(&s.client, &p.TopicName, p.Payload)
 	case *packets.SubscribePacket:
-		return s.event.AuthSubscribe(s.client, p.Topics)
+		return s.event.AuthSubscribe(&s.client, p.Topics)
 	default:
 		return nil
 	}
@@ -93,13 +93,13 @@ func (s *session) authorize(pkt packets.ControlPacket) error {
 func (s *session) notify(pkt packets.ControlPacket) {
 	switch p := pkt.(type) {
 	case *packets.ConnectPacket:
-		s.event.Connect(s.client)
+		s.event.Connect(&s.client)
 	case *packets.PublishPacket:
-		s.event.Publish(s.client, p.TopicName, p.Payload)
+		s.event.Publish(&s.client, &p.TopicName, p.Payload)
 	case *packets.SubscribePacket:
-		s.event.Subscribe(s.client, p.Topics)
+		s.event.Subscribe(&s.client, p.Topics)
 	case *packets.UnsubscribePacket:
-		s.event.Unsubscribe(s.client, p.Topics)
+		s.event.Unsubscribe(&s.client, p.Topics)
 	default:
 		return
 	}


### PR DESCRIPTION
Signed-off-by: Dušan Borovčanin <dusan.borovcanin@mainflux.com>

Use MQTT client as the first param in MQTT events. This provides a flexible, yet powerful interface that won't break if we change the client struct. As client struct is intended to be simple, effects on performance will be negligible.