### PR TITLE
NOISSUE - Add mqttv3.1 subprotocol in WS listener

### DIFF
--- a/pkg/websocket/websocket.go
+++ b/pkg/websocket/websocket.go
@@ -34,7 +34,7 @@ var upgrader = websocket.Upgrader{
 	// Timeout for WS upgrade request handshake
 	HandshakeTimeout: 10 * time.Second,
 	// Paho JS client expecting header Sec-WebSocket-Protocol:mqtt in Upgrade response during handshake.
-	Subprotocols: []string{"mqtt"},
+	Subprotocols: []string{"mqttv3.1"},
 	// Allow CORS
 	CheckOrigin: func(r *http.Request) bool {
 		return true
@@ -69,7 +69,7 @@ func (p Proxy) pass(in *websocket.Conn) {
 	}
 
 	dialer := &websocket.Dialer{
-		Subprotocols: []string{"mqtt"},
+		Subprotocols: []string{"mqttv3.1"},
 	}
 	srv, _, err := dialer.Dial(url.String(), nil)
 

--- a/pkg/websocket/websocket.go
+++ b/pkg/websocket/websocket.go
@@ -34,7 +34,7 @@ var upgrader = websocket.Upgrader{
 	// Timeout for WS upgrade request handshake
 	HandshakeTimeout: 10 * time.Second,
 	// Paho JS client expecting header Sec-WebSocket-Protocol:mqtt in Upgrade response during handshake.
-	Subprotocols: []string{"mqttv3.1"},
+	Subprotocols: []string{"mqttv3.1", "mqtt"},
 	// Allow CORS
 	CheckOrigin: func(r *http.Request) bool {
 		return true
@@ -69,7 +69,7 @@ func (p Proxy) pass(in *websocket.Conn) {
 	}
 
 	dialer := &websocket.Dialer{
-		Subprotocols: []string{"mqttv3.1"},
+		Subprotocols: []string{"mqtt"},
 	}
 	srv, _, err := dialer.Dial(url.String(), nil)
 


### PR DESCRIPTION
Signed-off-by: Ivan Milošević <iva@blokovi.com>

This PR is related to #11 PR

I had problem when I try WebSocket connection mProxy with hivemq ws client on one side and both mosquitto and vernemq brokers on other side.
Adding `mqttv3.1` to subprotocol list in upgrader resolve issue. 

To be noted that adding `mqttv3.1` to subprotocol list in dialer made another issue with VerneMQ (and just verne, not mosquitto). This is possible bug in VerneMQ that should be researched.