### PR TITLE
NOISSUE - Proxy crashes when using tls.VerifyClientCertIfGiven

### DIFF
--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -48,6 +48,9 @@ func ClientCert(conn net.Conn) (x509.Certificate, error) {
 		if state.Version == 0 {
 			return x509.Certificate{}, errTLSdetails
 		}
+		if len(state.PeerCertificates) == 0 {
+			return x509.Certificate{}, nil
+		}
 		cert := *state.PeerCertificates[0]
 		return cert, nil
 	default:


### PR DESCRIPTION
On our use case here, devices are gonna use TLS, but for the Authentication part, we want to allow both mTLS and username/password.

When creating the proxy with the configuration bellow, devices that try to use just username/password crash the proxy due to the `PeerCertificate` list being empty
```
tlsConfig: &tls.Config{
	MinVersion:   tls.VersionTLS12,
	Certificates: []tls.Certificate{*rootCert},
	ClientCAs:    certPool,
	ClientAuth:   tls.VerifyClientCertIfGiven,
},
```

Btw, awesome projects, we manage to offload the authentication part of our platform using this project. 