### PR TITLE
NOISSUE - Add MQTT packet interceptor

### DIFF
--- a/pkg/session/interceptor.go
+++ b/pkg/session/interceptor.go
@@ -1,0 +1,12 @@
+package session
+
+import "github.com/eclipse/paho.mqtt.golang/packets"
+
+// Interceptor is an interface for mProxy intercept hook
+type Interceptor interface {
+	// Intercept is called on every packet flowing through the proxy
+	// packets can be modified before being sent to the broker or the client
+	// If the interceptor returns a non-nil packet, the modified packet is sent
+	// If the interceptor returns nil or error, the original packet is send
+	Intercept(pkt packets.ControlPacket, c *Client, d Direction) (packets.ControlPacket, error)
+}


### PR DESCRIPTION
The idea behind this feature is to allow the proxy to modify MQTT packets flowing through.

In our use case, we wanted to build something like "Apache mod_rewrite" and to allow devices to Publish/Subscribe on the gateway on their own path, without relying on prefix using the device ID or other types of prefixes for example.

So instead of devices using topics like `/devices/{device-id}/data/#` or `/region/{region}/devices/{device-id}/command` like a lot of cloud providers do to isolate devices on the broker, we wanted for devices to use just the path to what it wants to publish/subscribe, almost like they have their own isolate broker. So devices would use topics like `/data/#` or `/command` and the proxy will add/remove the prefix when going back and forth with the broker that is being proxied ( like mod_rewrite 😅  )

I added this new interface called `Interceptor`, which is optional ( to avoid breaking changes )  and allows users to modify packets as they flow through the proxy. 

Here is an example of a proxy that adds the prefix on upstream packets and removes it from downstream packets. It's working internally here for our use case.

```
proxy := mqtt.New(address, target, gp, gp.logger).WithInterceptor(gp)

func rewriteTopic(topic, prefix string, dir session.Direction) string {
	//if strings.HasPrefix(topic, prefix) {
	if dir == session.Upstream {
		return filepath.Join(prefix, topic)
	}
	return strings.TrimPrefix(topic, prefix)
}

func rewriteTopicSlice(topics []string, prefix string, dir session.Direction) []string {
	for i, t := range topics {
		topics[i] = rewriteTopic(t, prefix, dir)
	}
	return topics
}

// Intercept can change packet before sending/receiving
func (gp *GatewayProxy) Intercept(pkt packets.ControlPacket, c *session.Client, dir session.Direction) (packets.ControlPacket, error) {
	prefix := "/devices/" + c.ID + "/"
	switch p := pkt.(type) {
	case *packets.PublishPacket:
		p.TopicName = rewriteTopic(p.TopicName, prefix, dir)
		return p, nil
	case *packets.SubscribePacket:
		p.Topics = rewriteTopicSlice(p.Topics, prefix, dir)
		return p, nil
	case *packets.UnsubscribePacket:
		p.Topics = rewriteTopicSlice(p.Topics, prefix, dir)
		return p, nil
	default:
		return pkt, nil
	}
}
```

Let me know if that makes sense and/or if you think there is a better way of doing that. I could have added to the same `Handler` interface, but some decisions here were made with the lens of avoiding breaking changes. 